### PR TITLE
ci: add dependabot to the project

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+- package-ecosystem: gradle
+  directory: "/"
+  schedule:
+    interval: daily
+    time: '09:00'
+  open-pull-requests-limit: 30
+  assignees:
+  - Chesire
+
+- package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: daily
+    time: '09:00'
+  open-pull-requests-limit: 30
+  assignees:
+  - Chesire
+
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: '09:00'
+  open-pull-requests-limit: 30
+  assignees:
+  - Chesire


### PR DESCRIPTION
Add dependabot to update the Gradle dependencies, bundler dependencies, and GitHub actions