### PR TITLE
chore: fix the build warning for enabling viewbinding

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,8 +19,8 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
-    viewBinding {
-        enabled = true
+    buildFeatures {
+        viewBinding true
     }
     compileOptions {
         sourceCompatibility = 1.8


### PR DESCRIPTION
The way to enable ViewBinding has changed since this project was started, so update to use the
latest way to do it