### PR TITLE
refactor: rename app to pushie

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# PassPusher
-![Android CI](https://github.com/Chesire/PassPusher/workflows/Android%20CI/badge.svg?branch=master)  
+# Pushie
+![Android CI](https://github.com/Chesire/Pushie/workflows/Android%20CI/badge.svg?branch=master)  
 Android application to interface with the PasswordPusher API https://github.com/pglombardo/PasswordPusher/wiki/Password-API

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ apply plugin: "kotlin-android-extensions"
 android {
     compileSdkVersion 30
     defaultConfig {
-        applicationId "com.chesire.passpusher"
+        applicationId "com.chesire.pushie"
         minSdkVersion 23
         targetSdkVersion 30
         versionCode 1

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.chesire.passpusher">
+    package="com.chesire.pushie">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
@@ -12,7 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:name=".MainActivity"
+            android:name="com.chesire.pushie.MainActivity"
             android:label="@string/process_text_action_text">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/chesire/pushie/MainActivity.kt
+++ b/app/src/main/java/com/chesire/pushie/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.chesire.passpusher
+package com.chesire.pushie
 
 import android.content.ClipboardManager
 import android.content.Context
@@ -10,9 +10,9 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import com.chesire.passpusher.api.PasswordPusher
-import com.chesire.passpusher.databinding.ActivityMainBinding
-import com.chesire.passpusher.extension.closeKeyboard
+import com.chesire.pushie.api.PasswordPusher
+import com.chesire.pushie.databinding.ActivityMainBinding
+import com.chesire.pushie.extension.closeKeyboard
 import com.google.android.material.snackbar.Snackbar
 import okhttp3.OkHttpClient
 

--- a/app/src/main/java/com/chesire/pushie/MainViewModel.kt
+++ b/app/src/main/java/com/chesire/pushie/MainViewModel.kt
@@ -1,4 +1,4 @@
-package com.chesire.passpusher
+package com.chesire.pushie
 
 import android.content.ClipData
 import android.content.ClipboardManager
@@ -6,7 +6,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.chesire.passpusher.api.PasswordAPI
+import com.chesire.pushie.api.PasswordAPI
 import kotlinx.coroutines.launch
 
 /**
@@ -42,7 +42,7 @@ class MainViewModel(
     }
 
     private fun copyToClipboard(value: String) =
-        clipboard.setPrimaryClip(ClipData.newPlainText("PassPusher", value))
+        clipboard.setPrimaryClip(ClipData.newPlainText("Pushie", value))
 
     /**
      * Different possible states of the api request.

--- a/app/src/main/java/com/chesire/pushie/api/PasswordAPI.kt
+++ b/app/src/main/java/com/chesire/pushie/api/PasswordAPI.kt
@@ -1,4 +1,4 @@
-package com.chesire.passpusher.api
+package com.chesire.pushie.api
 
 /**
  * Provides methods for pushing passwords up to an API.

--- a/app/src/main/java/com/chesire/pushie/api/PasswordPusher.kt
+++ b/app/src/main/java/com/chesire/pushie/api/PasswordPusher.kt
@@ -1,4 +1,4 @@
-package com.chesire.passpusher.api
+package com.chesire.pushie.api
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext

--- a/app/src/main/java/com/chesire/pushie/api/PushedModel.kt
+++ b/app/src/main/java/com/chesire/pushie/api/PushedModel.kt
@@ -1,4 +1,4 @@
-package com.chesire.passpusher.api
+package com.chesire.pushie.api
 
 /**
  * Model containing the result data from pushing a password using [PasswordAPI.sendPassword].

--- a/app/src/main/java/com/chesire/pushie/extension/ActivityExtensions.kt
+++ b/app/src/main/java/com/chesire/pushie/extension/ActivityExtensions.kt
@@ -1,4 +1,4 @@
-package com.chesire.passpusher.extension
+package com.chesire.pushie.extension
 
 import android.app.Activity
 import android.content.Context

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="app_name">PassPusher</string>
-    <string name="process_text_action_text">PassPush</string>
+    <string name="app_name">Pushie</string>
+    <string name="process_text_action_text">Pushie</string>
     <string name="password_hint">Enter password</string>
     <string name="days_expiry_text">Days till expiry</string>
     <string name="views_expiry_text">Views till expiry</string>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
-rootProject.name='PassPusher'
+rootProject.name='Pushie'
 include ':app'


### PR DESCRIPTION
Change the name of the application from PassPush to Pushie, PassPush is a little too close to the name of the website with the API that is being used.

It would also make sense to change the repository name to match.