### PR TITLE
ci: remove the public stage from ci as Bitrise will handle this

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -5,8 +5,6 @@ on:
     branches: [ master ]
   pull_request_target:
     branches: [ master ]
-  release:
-    types: [ published ]
 
 jobs:
   assemble:
@@ -96,23 +94,3 @@ jobs:
         danger_id: 'danger-ci'
       env:
         DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_API_TOKEN }}
-
-  deploy:
-    needs: [ assemble, analyze ]
-    if: github.event_name == 'release'
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        ref: ${{github.event.pull_request.head.ref}}
-        repository: ${{github.event.pull_request.head.repo.full_name}}
-        fetch-depth: 0
-    - name: set up JDK 1.8
-      uses: actions/setup-java@v1.4.3
-      with:
-        java-version: 1.8
-    - name: Fetch tags
-      run: git fetch origin 'refs/tags/*:refs/tags/*'
-    - name: run assemble
-      run: ./gradlew assemble
-    # add stages to deploy via fastlane


### PR DESCRIPTION
Instead of running publish from the GitHub actions, let Bitrise handle doing this