### PR TITLE
fix: stop a crash when the password entered is empty

### DIFF
--- a/app/src/main/java/com/chesire/pushie/MainActivity.kt
+++ b/app/src/main/java/com/chesire/pushie/MainActivity.kt
@@ -94,6 +94,12 @@ class MainActivity : AppCompatActivity() {
                             .make(binding.root, R.string.result_failure, Snackbar.LENGTH_LONG)
                             .show()
                     }
+                    MainViewModel.ApiState.EmptyPassword -> {
+                        setLoadingIndicatorState(false)
+                        Snackbar
+                            .make(binding.root, R.string.result_empty_password, Snackbar.LENGTH_LONG)
+                            .show()
+                    }
                 }
             }
         )

--- a/app/src/main/java/com/chesire/pushie/MainViewModel.kt
+++ b/app/src/main/java/com/chesire/pushie/MainViewModel.kt
@@ -29,7 +29,11 @@ class MainViewModel(
      * Send the current details up to the api, result will be synced along the [apiState] live data.
      */
     fun sendApiRequest(password: String, expiryDays: Int, expiryViews: Int) {
-        // TODO: check password isn't blank
+        if (password.isBlank()) {
+            _apiState.postValue(ApiState.EmptyPassword)
+            return
+        }
+
         _apiState.postValue(ApiState.InProgress)
         viewModelScope.launch {
             val result = passwordPusher.sendPassword(password, expiryDays, expiryViews)
@@ -50,6 +54,7 @@ class MainViewModel(
     enum class ApiState {
         InProgress,
         Success,
-        Failure
+        Failure,
+        EmptyPassword
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,10 +1,14 @@
 <resources>
     <string name="app_name">Pushie</string>
+
     <string name="process_text_action_text">Pushie</string>
+
     <string name="password_hint">Enter password</string>
     <string name="days_expiry_text">Days till expiry</string>
     <string name="views_expiry_text">Views till expiry</string>
     <string name="main_send">Send</string>
+
     <string name="result_success">Result copied to clipboard</string>
     <string name="result_failure">Request failed, please try again…</string>
+    <string name="result_empty_password">Please enter a password</string>
 </resources>


### PR DESCRIPTION
If there is an empty password then the ViewModel should return a different error object to account
for this. So that the Fragment can display a different error message.