### PR TITLE
fix: use a LiveEvent instead of Livedata for api result

### DIFF
--- a/feature/pusher/build.gradle.kts
+++ b/feature/pusher/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1")
     implementation("com.chesire.lintrules:lint-gradle:1.2.6")
     implementation("com.chesire.lintrules:lint-xml:1.2.6")
+    implementation("com.github.hadilq:live-event:1.2.3")
     implementation("com.google.android.material:material:1.3.0")
     implementation("com.squareup.okhttp3:okhttp:4.9.1")
 

--- a/feature/pusher/src/main/java/com/chesire/pushie/pusher/PusherViewModel.kt
+++ b/feature/pusher/src/main/java/com/chesire/pushie/pusher/PusherViewModel.kt
@@ -1,9 +1,9 @@
 package com.chesire.pushie.pusher
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.hadilq.liveevent.LiveEvent
 import kotlinx.coroutines.launch
 
 /**
@@ -14,7 +14,7 @@ class PusherViewModel(
     private val clipboardInteractor: ClipboardInteractor
 ) : ViewModel() {
 
-    private val _apiState = MutableLiveData<ApiState>()
+    private val _apiState = LiveEvent<ApiState>()
 
     /**
      * The current state of the api request.


### PR DESCRIPTION
## Description of the change
Use LiveEvent so it only occurs once, this stops the LiveData firing a second time if navigating
between the settings and pusher view.