### PR TITLE
fix: unable to send request to pwpush api

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,8 +9,8 @@ android {
         minSdk = 21
         targetSdk = 31
         applicationId = "com.chesire.pushie"
-        versionCode = 9
-        versionName = "2.0.1"
+        versionCode = 10
+        versionName = "2.0.2"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         resourceConfigurations.add("en")
     }

--- a/library/datasource/pwpush/src/main/java/com/chesire/pushie/datasource/pwpush/remote/PushedModel.kt
+++ b/library/datasource/pwpush/src/main/java/com/chesire/pushie/datasource/pwpush/remote/PushedModel.kt
@@ -5,11 +5,6 @@ package com.chesire.pushie.datasource.pwpush.remote
  */
 data class PushedModel(
     /**
-     * Unique ID of the password that was sent up.
-     */
-    val id: Int,
-
-    /**
      * Timestamp of when the password was created, in format 2020-05-23T17:45:15.602Z.
      */
     val createdAt: String,

--- a/library/datasource/pwpush/src/main/java/com/chesire/pushie/datasource/pwpush/remote/PusherApi.kt
+++ b/library/datasource/pwpush/src/main/java/com/chesire/pushie/datasource/pwpush/remote/PusherApi.kt
@@ -89,7 +89,6 @@ class PusherApi(
     private fun createPushedModel(jsonBody: String): PushedModel {
         return with(JSONObject(jsonBody)) {
             PushedModel(
-                getInt("id"),
                 getString("created_at"),
                 createPasswordUrl(getString("url_token"))
             )


### PR DESCRIPTION
## Description of the change
Removed the `ID` field from the parsed model so we no longer look into the response for it.

## Reason for the change
The API had removed the ID field from the response, so when trying to get this field from the json response we were failing to parse it and throwing an error.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have fixed all new raised warnings
