### PR TITLE
feat: make use of the Result library

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.{kt,kts}]
+disabled_rules = import-ordering

--- a/feature/pusher/build.gradle.kts
+++ b/feature/pusher/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation("com.chesire.lintrules:lint-xml:1.2.6")
     implementation("com.github.hadilq:live-event:1.3.0")
     implementation("com.google.android.material:material:1.5.0")
+    implementation("com.michael-bull.kotlin-result:kotlin-result:1.1.14")
     implementation("com.squareup.okhttp3:okhttp:4.9.3")
 
     testImplementation("junit:junit:4.13.2")

--- a/feature/pusher/src/main/java/com/chesire/pushie/pusher/PusherInteractor.kt
+++ b/feature/pusher/src/main/java/com/chesire/pushie/pusher/PusherInteractor.kt
@@ -1,7 +1,8 @@
 package com.chesire.pushie.pusher
 
 import com.chesire.pushie.datasource.pwpush.PWPushRepository
-import com.chesire.pushie.datasource.pwpush.remote.ApiResult
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.mapEither
 
 /**
  * Interacts with the [PWPushRepository] to send up passwords and generate urls.
@@ -15,12 +16,12 @@ class PusherInteractor(private val repository: PWPushRepository) {
         password: String,
         expiryDays: Int,
         expiryViews: Int
-    ): SendPasswordResult {
-        return when (val sendResult = repository.sendPassword(password, expiryDays, expiryViews)) {
-            is ApiResult.Success -> SendPasswordResult.Success(sendResult.model.url)
-            is ApiResult.Error -> SendPasswordResult.Error
-            is ApiResult.ExceptionalError -> SendPasswordResult.Error
-        }
+    ): Result<SendPasswordResult.Success, SendPasswordResult.Error> {
+        return repository.sendPassword(password, expiryDays, expiryViews)
+            .mapEither(
+                success = { SendPasswordResult.Success(it.url) },
+                failure = { SendPasswordResult.Error }
+            )
     }
 }
 

--- a/feature/pusher/src/main/java/com/chesire/pushie/pusher/PusherViewModel.kt
+++ b/feature/pusher/src/main/java/com/chesire/pushie/pusher/PusherViewModel.kt
@@ -3,6 +3,8 @@ package com.chesire.pushie.pusher
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.github.michaelbull.result.onFailure
+import com.github.michaelbull.result.onSuccess
 import com.hadilq.liveevent.LiveEvent
 import kotlinx.coroutines.launch
 
@@ -43,13 +45,14 @@ class PusherViewModel(
 
         _apiState.postValue(ApiState.InProgress)
         viewModelScope.launch {
-            when (val result = pushInteractor.sendNewPassword(password, expiryDays, expiryViews)) {
-                is SendPasswordResult.Success -> {
-                    clipboardInteractor.copyToClipboard(result.url)
+            pushInteractor.sendNewPassword(password, expiryDays, expiryViews)
+                .onSuccess {
+                    clipboardInteractor.copyToClipboard(it.url)
                     _apiState.postValue(ApiState.Success)
                 }
-                SendPasswordResult.Error -> _apiState.postValue(ApiState.Failure)
-            }
+                .onFailure {
+                    _apiState.postValue(ApiState.Failure)
+                }
         }
     }
 

--- a/library/common/src/main/java/com/chesire/pushie/common/ApiError.kt
+++ b/library/common/src/main/java/com/chesire/pushie/common/ApiError.kt
@@ -1,0 +1,9 @@
+package com.chesire.pushie.common
+
+/**
+ * Information that can come back from a call to an API.
+ */
+data class ApiError(
+    val code: Int? = null,
+    val throwable: Throwable? = null
+)

--- a/library/datasource/pwpush/build.gradle.kts
+++ b/library/datasource/pwpush/build.gradle.kts
@@ -14,12 +14,14 @@ android {
 }
 
 dependencies {
+    implementation(project(":library:common"))
     implementation(project(":library:datastore"))
 
     implementation("androidx.appcompat:appcompat:1.4.1")
     implementation("androidx.core:core-ktx:1.7.0")
     implementation("com.chesire.lintrules:lint-gradle:1.2.6")
     implementation("com.chesire.lintrules:lint-xml:1.2.6")
+    implementation("com.michael-bull.kotlin-result:kotlin-result:1.1.14")
     implementation("com.squareup.okhttp3:okhttp:4.9.3")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2")

--- a/library/datasource/pwpush/src/main/java/com/chesire/pushie/datasource/pwpush/PWPushRepository.kt
+++ b/library/datasource/pwpush/src/main/java/com/chesire/pushie/datasource/pwpush/PWPushRepository.kt
@@ -1,7 +1,10 @@
 package com.chesire.pushie.datasource.pwpush
 
-import com.chesire.pushie.datasource.pwpush.remote.ApiResult
+import com.chesire.pushie.common.ApiError
+import com.chesire.pushie.datasource.pwpush.remote.PushedModel
 import com.chesire.pushie.datasource.pwpush.remote.PusherApi
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.onSuccess
 
 /**
  * Repository to interact with the [PusherApi] remote data source, and to interact with any local
@@ -10,15 +13,17 @@ import com.chesire.pushie.datasource.pwpush.remote.PusherApi
 class PWPushRepository(private val passwordAPI: PusherApi) {
 
     /**
-     * Sends the [password] up to the API, returning an [ApiResult] in response.
+     * Sends the [password] up to the API.
      */
     suspend fun sendPassword(
         password: String,
         expiryDays: Int,
         expiryViews: Int
-    ): ApiResult {
-        val result = passwordAPI.sendPassword(password, expiryDays, expiryViews)
-        // TODO: store in local db, with a flow available to return these urls
-        return result
+    ): Result<PushedModel, ApiError> {
+        return passwordAPI
+            .sendPassword(password, expiryDays, expiryViews)
+            .onSuccess {
+                // TODO: store in local db. Use a flow from there to return these urls
+            }
     }
 }


### PR DESCRIPTION
## Description of the change
Use the result library to handle communication from the api back down to the ViewModel.

Closes -

## Reason for the change
It's a bit nicer to use the result library, just a cosmetic change more than anything at the moment.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have fixed all new raised warnings
