### PR TITLE
chore: remove JCenter

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,7 +39,5 @@ dependencies {
 
     implementation("androidx.appcompat:appcompat:1.4.1")
     implementation("androidx.preference:preference-ktx:1.2.0")
-    implementation("com.chesire.lintrules:lint-gradle:1.2.6")
-    implementation("com.chesire.lintrules:lint-xml:1.2.6")
     implementation("com.google.android.material:material:1.5.0")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import org.jlleitschuh.gradle.ktlint.KtlintPlugin
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:7.1.1")
@@ -21,7 +21,7 @@ plugins {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/feature/pusher/build.gradle.kts
+++ b/feature/pusher/build.gradle.kts
@@ -28,8 +28,6 @@ dependencies {
     implementation("androidx.fragment:fragment-ktx:1.4.1")
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.4.1")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.1")
-    implementation("com.chesire.lintrules:lint-gradle:1.2.6")
-    implementation("com.chesire.lintrules:lint-xml:1.2.6")
     implementation("com.github.hadilq:live-event:1.3.0")
     implementation("com.google.android.material:material:1.5.0")
     implementation("com.michael-bull.kotlin-result:kotlin-result:1.1.14")

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -22,6 +22,4 @@ dependencies {
     implementation(project(":library:resources"))
 
     implementation("androidx.preference:preference-ktx:1.2.0")
-    implementation("com.chesire.lintrules:lint-gradle:1.2.6")
-    implementation("com.chesire.lintrules:lint-xml:1.2.6")
 }

--- a/library/datasource/pwpush/build.gradle.kts
+++ b/library/datasource/pwpush/build.gradle.kts
@@ -19,8 +19,6 @@ dependencies {
 
     implementation("androidx.appcompat:appcompat:1.4.1")
     implementation("androidx.core:core-ktx:1.7.0")
-    implementation("com.chesire.lintrules:lint-gradle:1.2.6")
-    implementation("com.chesire.lintrules:lint-xml:1.2.6")
     implementation("com.michael-bull.kotlin-result:kotlin-result:1.1.14")
     implementation("com.squareup.okhttp3:okhttp:4.9.3")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0")


### PR DESCRIPTION
## Description of the change
JCenter is no longer needed, and instead mavenCentral should be used. The LintRules repository is
currently not available elsewhere, and cannot be pulled in via Jitpack so remove for now

Closes -

## Reason for the change
JCenter will be removed and is prompting a warning.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have fixed all new raised warnings
