### PR TITLE
chore: move Kotlin version out of toml file

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:7.2.1")
         classpath("com.google.dagger:hilt-android-gradle-plugin:${libs.versions.hilt.get()}")
-        classpath(kotlin("gradle-plugin", libs.versions.kotlin.get()))
+        classpath(kotlin("gradle-plugin", "1.6.10"))
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,6 @@
 compose = "1.1.1"
 coroutines = "1.6.2"
 hilt = "2.38.1"
-kotlin = "1.6.10"
 lifecycle = "2.4.1"
 
 [libraries]


### PR DESCRIPTION
## Description of the change
The Kotlin version can be stored in just the build.gradle.kts.

## Reason for the change
Because Kotlin isn't used in the toml file I think renovate can't update it.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have fixed all new raised warnings
