### PR TITLE
feat: add setting for default days and views

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetSelector">
+    <selectionStates>
+      <SelectionState runConfigName="app">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+    </selectionStates>
+  </component>
+</project>

--- a/.idea/studiobot.xml
+++ b/.idea/studiobot.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="StudioBotProjectSettings">
+    <option name="shareContext" value="OptedOut" />
+  </component>
+</project>

--- a/feature/pusher/src/main/java/com/chesire/pushie/pusher/ui/PusherViewModel.kt
+++ b/feature/pusher/src/main/java/com/chesire/pushie/pusher/ui/PusherViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.chesire.pushie.common.getStateFlow
+import com.chesire.pushie.datastore.PreferenceStore
 import com.chesire.pushie.pusher.DAYS_PICKER_BUNDLE_KEY
 import com.chesire.pushie.pusher.PW_KEY
 import com.chesire.pushie.pusher.R
@@ -29,7 +30,8 @@ private const val STATE_KEY = "PUSHER_STATE_KEY"
 class PusherViewModel @Inject constructor(
     state: SavedStateHandle,
     private val pushInteractor: PusherInteractor,
-    private val clipboardInteractor: ClipboardInteractor
+    private val clipboardInteractor: ClipboardInteractor,
+    private val preferenceStore: PreferenceStore
 ) : ViewModel() {
 
     private val _apiState = LiveEvent<ApiResult>()
@@ -47,8 +49,8 @@ class PusherViewModel @Inject constructor(
         viewModelScope,
         ViewState(
             passwordText = state.get<String>(PW_KEY) ?: "",
-            expiryDays = state.get<Int>(DAYS_PICKER_BUNDLE_KEY) ?: 7,
-            expiryViews = state.get<Int>(VIEWS_PICKER_BUNDLE_KEY) ?: 5,
+            expiryDays = state.get<Int>(DAYS_PICKER_BUNDLE_KEY) ?: preferenceStore.defaultDaysTillExpiry,
+            expiryViews = state.get<Int>(VIEWS_PICKER_BUNDLE_KEY) ?: preferenceStore.defaultViewsTillExpiry,
             isLoading = false,
             previousModels = emptyList()
         )

--- a/feature/settings/src/main/java/com/chesire/pushie/settings/SettingsFragment.kt
+++ b/feature/settings/src/main/java/com/chesire/pushie/settings/SettingsFragment.kt
@@ -1,7 +1,9 @@
 package com.chesire.pushie.settings
 
 import android.os.Bundle
+import android.text.InputType
 import androidx.lifecycle.lifecycleScope
+import androidx.preference.EditTextPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import com.chesire.pushie.datasource.pwpush.local.dao.PushedDao
@@ -19,12 +21,19 @@ class SettingsFragment : PreferenceFragmentCompat() {
     lateinit var pushedDao: PushedDao
 
     private lateinit var clearHistoryPreference: String
+    private lateinit var defaultDaysPreference: String
+    private lateinit var defaultViewsPreference: String
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         preferenceManager.sharedPreferencesName = getString(R.string.preference_file_name)
         clearHistoryPreference = getString(R.string.key_clear_history)
+        defaultDaysPreference = getString(R.string.key_default_days)
+        defaultViewsPreference = getString(R.string.key_default_views)
 
         setPreferencesFromResource(R.xml.pref_settings, rootKey)
+
+        setupDefaultPreference(defaultDaysPreference, 90)
+        setupDefaultPreference(defaultViewsPreference, 100)
     }
 
     override fun onPreferenceTreeClick(preference: Preference): Boolean {
@@ -36,6 +45,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 showClearHistorySnackbar()
                 true
             }
+
             else -> super.onPreferenceTreeClick(preference)
         }
     }
@@ -47,6 +57,24 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 R.string.settings_clear_history_finished,
                 Snackbar.LENGTH_LONG
             ).show()
+        }
+    }
+
+    private fun setupDefaultPreference(preferenceValue: String, maxValue: Int) {
+        preferenceManager.findPreference<EditTextPreference>(preferenceValue)?.let { pref ->
+            pref.setOnBindEditTextListener {
+                it.inputType = InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_SIGNED
+            }
+            pref.setOnPreferenceChangeListener { _, newValue ->
+                val new = newValue.toString().toIntOrNull()
+                if (new == null) {
+                    false
+                } else if (new < 1 || new > maxValue) {
+                    false
+                } else {
+                    true
+                }
+            }
         }
     }
 }

--- a/feature/settings/src/main/res/xml/pref_settings.xml
+++ b/feature/settings/src/main/res/xml/pref_settings.xml
@@ -6,6 +6,22 @@
         android:summary="@string/settings_default_url_summary"
         android:title="@string/settings_default_url_title" />
 
+    <EditTextPreference
+        android:defaultValue="@integer/default_default_days"
+        android:key="@string/key_default_days"
+        android:summary="@string/settings_default_days_summary"
+        android:title="@string/settings_default_days_title"
+        android:inputType="numberDecimal"
+        android:digits="0123456789" />
+
+    <EditTextPreference
+        android:defaultValue="@integer/default_default_views"
+        android:key="@string/key_default_views"
+        android:summary="@string/settings_default_views_summary"
+        android:title="@string/settings_default_views_title"
+        android:inputType="numberDecimal"
+        android:digits="0123456789" />
+
     <Preference
         android:key="@string/key_clear_history"
         android:title="@string/settings_clear_history_title"

--- a/library/datastore/src/main/java/com/chesire/pushie/datastore/PreferenceStore.kt
+++ b/library/datastore/src/main/java/com/chesire/pushie/datastore/PreferenceStore.kt
@@ -11,16 +11,34 @@ class PreferenceStore @Inject constructor(@ApplicationContext context: Context) 
         context.getString(R.string.preference_file_name),
         MODE_PRIVATE
     )
-    private val _pushieUrlModel = PreferenceModel(
+    private val _pushieUrlModel = PreferenceStringModel(
         context.getString(R.string.key_default_url),
         context.getString(R.string.default_default_url)
     )
+    private val _defaultDaysTillExpiry = PreferenceIntModel(
+        context.getString(R.string.key_default_days),
+        context.resources.getInteger(R.integer.default_default_days)
+    )
+    private val _defaultViewsTillExpiry = PreferenceIntModel(
+        context.getString(R.string.key_default_views),
+        context.resources.getInteger(R.integer.default_default_views)
+    )
 
     val pushieUrl: String
-        get() = preferences.getPreference(_pushieUrlModel)
+        get() = preferences.getString(_pushieUrlModel)
 
-    private fun SharedPreferences.getPreference(model: PreferenceModel): String =
+    val defaultDaysTillExpiry: Int
+        get() = preferences.getInt(_defaultDaysTillExpiry)
+
+    val defaultViewsTillExpiry: Int
+        get() = preferences.getInt(_defaultViewsTillExpiry)
+
+    private fun SharedPreferences.getString(model: PreferenceStringModel): String =
         getString(model.key, model.defaultValue) ?: model.defaultValue
+
+    private fun SharedPreferences.getInt(model: PreferenceIntModel): Int =
+        getString(model.key, model.defaultValue.toString())?.toIntOrNull() ?: model.defaultValue
 }
 
-private data class PreferenceModel(val key: String, val defaultValue: String)
+private data class PreferenceStringModel(val key: String, val defaultValue: String)
+private data class PreferenceIntModel(val key: String, val defaultValue: Int)

--- a/library/datastore/src/main/res/values/preference_default_values.xml
+++ b/library/datastore/src/main/res/values/preference_default_values.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="default_default_url" translatable="false">https://pwpush.com/p</string>
+    <integer name="default_default_days" translatable="false">7</integer>
+    <integer name="default_default_views" translatable="false">5</integer>
 </resources>

--- a/library/datastore/src/main/res/values/preference_keys.xml
+++ b/library/datastore/src/main/res/values/preference_keys.xml
@@ -2,5 +2,7 @@
 <resources>
     <string name="preference_file_name">PUSHIE_PREFERENCES</string>
     <string name="key_default_url" translatable="false">keyDefaultUrl</string>
+    <string name="key_default_days" translatable="false">keyDefaultDays</string>
+    <string name="key_default_views" translatable="false">keyDefaultViews</string>
     <string name="key_clear_history" translatable="false">keyClearHistory</string>
 </resources>

--- a/library/resources/src/main/res/values-ja/strings.xml
+++ b/library/resources/src/main/res/values-ja/strings.xml
@@ -16,6 +16,10 @@
     <string name="settings_title">設定</string>
     <string name="settings_default_url_title">PushieのURLを入力</string>
     <string name="settings_default_url_summary">詳細：APIに使用するURLを設定します</string>
+    <string name="settings_default_days_title">パスワードを削除するまでの日数</string>
+    <string name="settings_default_days_summary">パスワードの有効期限が切れるまでのデフォルトの日数を設定する</string>
+    <string name="settings_default_views_title">パスワードを削除するの閲覧可能回数</string>
+    <string name="settings_default_views_summary">パスワードの有効期限が切れるまでのデフォルトのビュー数を設定する</string>
     <string name="settings_clear_history_title">履歴をクリア</string>
     <string name="settings_clear_history_summary">以前にプッシュされたデータをすべてクリアします</string>
     <string name="settings_clear_history_finished">履歴がクリアされました</string>

--- a/library/resources/src/main/res/values/strings.xml
+++ b/library/resources/src/main/res/values/strings.xml
@@ -16,6 +16,10 @@
     <string name="settings_title">Settings</string>
     <string name="settings_default_url_title">Pushie URL</string>
     <string name="settings_default_url_summary">Advanced: Set the url to use for the API</string>
+    <string name="settings_default_days_title">Default days till expiry</string>
+    <string name="settings_default_days_summary">Set the default amount of days until the password expires. Max: 90</string>
+    <string name="settings_default_views_title">Default views till expiry</string>
+    <string name="settings_default_views_summary">Set the default amount of views until the password expires. Max: 100</string>
     <string name="settings_clear_history_title">Clear History</string>
     <string name="settings_clear_history_summary">Clear any previously pushed model data</string>
     <string name="settings_clear_history_finished">History has been cleared</string>


### PR DESCRIPTION
## Description of the change
Add new settings to the settings screen which allows the user to change the default days and views when opening the application.

Closes #372 

## Reason for the change
Good option to have in app.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have fixed all new raised warnings
